### PR TITLE
Redesign config handling, use serde instead. 

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -1,0 +1,42 @@
+name: Continuous integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+    container:
+      image: rust:latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Add clippy component
+        run: rustup component add clippy
+      - name: Run clippy
+        run: cargo clippy -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: rust:latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: cargo test
+
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: rust:latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build

--- a/.github/workflows/publishing.yml
+++ b/.github/workflows/publishing.yml
@@ -1,9 +1,7 @@
-name: Build (and publish)
+name: Publish release
 
 on:
   push:
-    branches:
-      - master
     tags:
       - "*"
 
@@ -11,25 +9,22 @@ env:
   GIT_SSH_COMMAND: ssh -i $HOME/.ssh/aur -o UserKnownHostsFile=$HOME/.ssh/known_hosts
 
 jobs:
-  build_and_test:
+  test:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/heads/')
     container:
       image: rust:latest
 
     steps:
       - uses: actions/checkout@v2
-      - name: Build
-        run: cargo build
       - name: Run tests
-        run: cargo test
+        run: cargo test --release
 
-  build_and_publish:
+  publish:
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     container:
       image: rust:latest
 
+    needs: test
     steps:
       - uses: actions/checkout@v2
       - name: Init SSH key and hosts
@@ -40,8 +35,6 @@ jobs:
           known_hosts: ${{ secrets.KNOWN_HOSTS_AUR }}
       - name: Checkout pkgbuild submodule
         run: git submodule update --init --force --depth=1
-      - name: Run tests
-        run: cargo test
       - name: Build binary
         run: cargo build --release
       - name: Generate tarball

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,19 +34,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "013a6e0a2cbe3d20f9c60b65458f7a7f7a5e636c5d0f45a5a6aee5d4b1f01785"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
-dependencies = [
- "nodrop",
-]
 
 [[package]]
 name = "arrayvec"
@@ -112,7 +109,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
 dependencies = [
  "arrayref",
- "arrayvec 0.5.1",
+ "arrayvec",
  "constant_time_eq",
 ]
 
@@ -154,18 +151,6 @@ name = "common_macros"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6d59c71e7dc3af60f0af9db32364d96a16e9310f3f5db2b55ed642162dd35"
-
-[[package]]
-name = "config"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b076e143e1d9538dde65da30f8481c2a6c44040edb8e02b9bf1351edb92ce3"
-dependencies = [
- "lazy_static",
- "nom",
- "serde",
- "toml 0.5.6",
-]
 
 [[package]]
 name = "constant_time_eq"
@@ -483,19 +468,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
-name = "lexical-core"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
-dependencies = [
- "arrayvec 0.4.12",
- "cfg-if",
- "rustc_version",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,12 +556,11 @@ name = "muso"
 version = "1.3.0"
 dependencies = [
  "ansi_term 0.12.1",
+ "anyhow",
  "cfg-if",
  "clap",
  "common_macros",
- "config",
  "dirs",
- "failure",
  "human-panic",
  "id3",
  "infer",
@@ -597,7 +568,10 @@ dependencies = [
  "log",
  "metaflac",
  "notify",
+ "serde",
  "shellexpand",
+ "thiserror",
+ "toml 0.5.6",
 ]
 
 [[package]]
@@ -609,23 +583,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi 0.3.8",
-]
-
-[[package]]
-name = "nodrop"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
-
-[[package]]
-name = "nom"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c433f4d505fe6ce7ff78523d2fa13a0b9f2690e181fc26168bcbe5ccc5d14e07"
-dependencies = [
- "lexical-core",
- "memchr",
- "version_check",
 ]
 
 [[package]]
@@ -773,21 +730,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
-name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,25 +739,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser",
-]
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
 name = "serde"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "414115f25f818d7dfccec8ee535d76949ae78584fc4f79a6f45a904bf8ab4449"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -842,12 +772,6 @@ name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
-
-[[package]]
-name = "static_assertions"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 
 [[package]]
 name = "strsim"
@@ -907,6 +831,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee14bf8e6767ab4c687c9e8bc003879e042a96fd67a3ba5934eadb6536bef4db"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7b51e1fbc44b5a0840be594fbc0f960be09050f2617e61e6aa43bef97cd3ef4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,12 +904,6 @@ name = "vec_map"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-
-[[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,32 +1,33 @@
 [package]
 name = "muso"
 version = "1.3.0"
-authors = ["Kevin <quebin31@gmail.com>"]
+authors = [ "Kevin <quebin31@gmail.com>" ]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-infer = "0.1.4"
-id3 = "0.5.0"
-metaflac = "0.2.1"
-clap = "2"
-dirs = "2"
-shellexpand = "2"
-notify = "4"
-log = "0.4.8"
 ansi_term = "0.12.1"
-human-panic = "1"
-lazy_static = "1"
-common_macros = "0.1"
-failure = "0.1"
+anyhow = "1"
 cfg-if = "0.1"
+clap = "2"
+common_macros = "0.1"
+dirs = "2"
+human-panic = "1"
+id3 = "0.5.0"
+infer = "0.1"
+lazy_static = "1"
+log = "0.4.8"
+metaflac = "0.2"
+notify = "4"
+shellexpand = "2"
+thiserror = "1"
+toml = "0.5"
 
-[dependencies.config]
-version = "0.10.1"
-default-features = false 
-features = [ "toml" ]
+[dependencies.serde]
+version = "1"
+features = [ "derive" ]
 
 [features]
-default = []
-standalone = []
+default = [ ]
+standalone = [ ]

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,0 +1,65 @@
+// Copyright (C) 2020 Kevin Dc
+//
+// This file is part of muso.
+//
+// muso is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// muso is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with muso.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::env;
+use std::path::PathBuf;
+
+use clap::ArgMatches;
+
+use crate::config::Config;
+use crate::error::Result;
+
+#[derive(Debug, Clone)]
+pub struct Args {
+    pub working_path: PathBuf,
+    pub format: String,
+    pub watch_mode: bool,
+    pub dryrun: bool,
+    pub recursive: bool,
+    pub exfat_compat: bool,
+}
+
+impl Args {
+    pub fn from_matches(matches: ArgMatches, config: &Config) -> Result<Self> {
+        let working_path: PathBuf = matches
+            .value_of("path")
+            .map_or(env::current_dir()?.to_string_lossy().into(), |path| {
+                path.to_string()
+            })
+            .into();
+
+        let format: String = matches
+            .value_of("format")
+            .map_or(config.search_format_for(&working_path), |f| Some(f))
+            .unwrap_or_else(|| "{artist}/{album}/{track} - {title}.{ext}")
+            .into();
+
+        let watch_mode = matches.is_present("watch");
+        let dryrun = matches.is_present("dryrun");
+        let recursive = matches.is_present("recursive");
+        let exfat_compat = matches.is_present("exfatcompat");
+
+        Ok(Self {
+            working_path,
+            format,
+            watch_mode,
+            dryrun,
+            recursive,
+            exfat_compat,
+        })
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,114 @@
+// Copyright (C) 2020 Kevin Dc
+//
+// This file is part of muso.
+//
+// muso is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// muso is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with muso.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+use serde::Deserialize;
+
+use crate::error::{MusoError, Result};
+use crate::utils;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WatchConfig {
+    pub every: Option<u64>,
+    pub libraries: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct LibraryConfig {
+    pub format: String,
+    pub folders: Vec<String>,
+    #[serde(rename = "exfat-compat")]
+    pub exfat_compat: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Config {
+    pub watch: WatchConfig,
+    pub libraries: HashMap<String, LibraryConfig>,
+}
+
+impl Config {
+    pub fn from_path(path: impl AsRef<Path>) -> Result<Self> {
+        let default = utils::default_config_path();
+        let path = path.as_ref();
+
+        if !path.exists() {
+            if path == default {
+                utils::generate_resource(utils::Resource::Config)?;
+            } else {
+                return Err(MusoError::InvalidConfig {
+                    path: path.to_string_lossy().into(),
+                    reason: "not found".into(),
+                }
+                .into());
+            }
+        }
+
+        let contents = fs::read_to_string(path)?;
+        let mut config: Self = toml::from_str(&contents).map_err(|e| MusoError::InvalidConfig {
+            path: path.to_string_lossy().into(),
+            reason: e.to_string(),
+        })?;
+
+        config.sanitize_paths();
+        Ok(config)
+    }
+
+    pub fn sanitize_paths(&mut self) {
+        for (name, library) in &mut self.libraries {
+            let mut sanitized: Vec<String> = Vec::new();
+
+            for folder in &library.folders {
+                match shellexpand::full(&folder) {
+                    Ok(full) => {
+                        let path = Path::new(full.as_ref());
+                        if path.exists() && path.is_absolute() {
+                            sanitized.push(full.as_ref().into());
+                        } else {
+                            log::warn! {
+                                "Library \"{}\" contains an invalid path: \"{}\"",
+                                name,
+                                full
+                            };
+                        }
+                    }
+
+                    Err(e) => {
+                        log::warn!("Library \"{}\" contains an invalid path: {}", name, e);
+                    }
+                }
+            }
+
+            library.folders = sanitized;
+        }
+    }
+
+    pub fn search_format_for(&self, path: impl AsRef<Path>) -> Option<&str> {
+        for library in self.libraries.values() {
+            for folder in &library.folders {
+                if Path::new(&folder) == path.as_ref() {
+                    return Some(&library.format);
+                }
+            }
+        }
+
+        None
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,25 +15,31 @@
 // You should have received a copy of the GNU General Public License
 // along with muso.  If not, see <http://www.gnu.org/licenses/>.
 
-use failure::Fail;
+use thiserror::Error;
 
-#[derive(Debug, PartialEq, Fail)]
+#[derive(Debug, PartialEq, Error)]
 pub enum MusoError {
-    #[fail(display = "File type not supported!")]
+    #[error("File type not supported!")]
     NotSupported,
 
-    #[fail(display = "Empty vorbis comments!")]
+    #[error("Empty vorbis comments!")]
     EmptyComments,
 
-    #[fail(display = "Parent directory is not valid!")]
-    BadParent,
+    #[error("Parent directory of \"{child}\" is not valid!")]
+    InvalidParent { child: String },
 
-    #[fail(display = "Path {} is not valid as root folder!", _0)]
-    InvalidRoot(String),
+    #[error("Path {path} is not valid as root folder!")]
+    InvalidRoot { path: String },
 
-    #[fail(display = "Tag property {} is missing!", _0)]
-    MissingTagProperty(String),
+    #[error("Tag property {tag} is missing!")]
+    MissingTag { tag: String },
 
-    #[fail(display = "Resource {} was not found!", _0)]
-    ResourceNotFound(String),
+    #[cfg(not(feature = "standalone"))]
+    #[error("Resource \"{path}\" was not found!")]
+    ResourceNotFound { path: String },
+
+    #[error("Invalid config file: \"{path}\" ({reason})")]
+    InvalidConfig { path: String, reason: String },
 }
+
+pub type Result<T> = std::result::Result<T, anyhow::Error>;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -34,8 +34,8 @@ impl Log for MusoLogger {
     fn log(&self, record: &Record) {
         match record.level() {
             Level::Info => println!("{} {}", Cyan.bold().paint("[i]"), record.args()),
-            Level::Warn => println!("{} {}", Yellow.bold().paint("[w]"), record.args()),
-            Level::Error => println!("{} {}", Red.bold().paint("[e]"), record.args()),
+            Level::Warn => eprintln!("{} {}", Yellow.bold().paint("[w]"), record.args()),
+            Level::Error => eprintln!("{} {}", Red.bold().paint("[e]"), record.args()),
             _ => {}
         }
     }

--- a/src/muso.rs
+++ b/src/muso.rs
@@ -17,11 +17,14 @@
 
 use std::collections::{HashMap, HashSet};
 use std::env::current_dir;
-use std::fs::{copy, create_dir_all, read_dir, remove_dir, rename, File};
-use std::io::{self, Write};
+use std::fs::{copy, create_dir_all, read_dir, remove_dir, rename};
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::time::Duration;
+
+#[cfg(feature = "standalone")]
+use std::{fs::File, io::Write};
 
 use cfg_if::cfg_if;
 use clap::ArgMatches;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,119 @@
+// Copyright (C) 2020 Kevin Dc
+//
+// This file is part of muso.
+//
+// muso is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// muso is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with muso.  If not, see <http://www.gnu.org/licenses/>.
+
+#[cfg(feature = "standalone")]
+use std::{fs::File, io::Write};
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::error::{MusoError, Result};
+
+#[inline]
+pub fn default_config_path() -> PathBuf {
+    dirs::config_dir().unwrap().join("muso/config.toml")
+}
+
+#[inline]
+pub fn default_service_path() -> PathBuf {
+    dirs::config_dir()
+        .unwrap()
+        .join("systemd/muso/muso.service")
+}
+
+pub fn maybe_create_dir(path: impl AsRef<Path>) -> std::io::Result<()> {
+    match fs::create_dir_all(path) {
+        Err(e) => match e.kind() {
+            std::io::ErrorKind::AlreadyExists => Ok(()),
+            _ => Err(e),
+        },
+        Ok(_) => Ok(()),
+    }
+}
+
+pub fn is_empty_dir(path: impl AsRef<Path>) -> Result<bool> {
+    if !path.as_ref().is_dir() {
+        Ok(false)
+    } else {
+        Ok(fs::read_dir(path)?.count() == 0)
+    }
+}
+
+pub enum Resource {
+    Config,
+    Service,
+}
+
+pub fn generate_resource(res: Resource) -> Result<()> {
+    let name = match res {
+        Resource::Config => "config",
+        Resource::Service => "service",
+    };
+
+    let dest = match res {
+        Resource::Config => default_config_path(),
+        Resource::Service => default_service_path(),
+    };
+
+    log::info!("Generating {} file", name);
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "standalone")] {
+            log::info!("Writing {} file", name);
+
+            maybe_create_dir(dest.parent().ok_or(MusoError::InvalidParent {
+                child: dest.to_string_lossy().into(),
+            })?)?;
+
+            let mut file = File::create(&dest)?;
+            let contents = match res {
+                Resource::Config => include_str!("../share/config.toml"),
+                Resource::Service => include_str!("../share/muso.service"),
+            };
+
+            write!(file, "{}", contents)?;
+
+            log::info!("Successfully written to: \"{}\"", dest.to_string_lossy());
+        } else {
+            let shared = match res {
+                Resource::Config => Path::new("/usr/share/muso/muso.service"),
+                Resource::Service => Path::new("/usr/share/muso/config.toml"),
+            };
+
+            if !shared.exists() {
+                return Err(MusoError::ResourceNotFound {
+                    path: shared.to_string_lossy().into(),
+                }.into());
+            } else {
+                log::info!("Copying {} file from shared assets", name);
+
+                maybe_create_dir(dest.parent().ok_or(MusoError::InvalidParent {
+                    child: dest.to_string_lossy().into(),
+                })?)?;
+                fs::copy(shared, &dest)?;
+
+                log::info! {
+                    "Successfully copied to: \"{}\"",
+                    dest.to_string_lossy()
+                };
+            }
+        }
+    }
+
+    log::info!("Successfully generated {} file", name);
+    Ok(())
+}


### PR DESCRIPTION
Going to remove the dependency on `config` crate to use `serde` + `toml` instead.

- [x] Config structure and substructures (templating).
- [x] Integrate with serde.
- [x] Replace all uses of old config.

More changes:
- [x] Args structure
- [x] Code clean up (new modules, logic moved)
- [x] Deprecate use of `failure`