### PR TITLE
Add support for optional tags using '?'

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "muso"
-version = "1.4.1"
+version = "1.5.0"
 dependencies = [
  "ansi_term 0.12.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "muso"
-version = "1.4.1"
-authors = [ "Kevin <quebin31@gmail.com>" ]
+authors = ["Kevin <quebin31@gmail.com>"]
 edition = "2018"
+name = "muso"
+version = "1.5.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,20 +17,20 @@ human-panic = "1"
 id3 = "0.5.0"
 infer = "0.1"
 lazy_static = "1"
+lewton = "0.10"
 log = "0.4.8"
 metaflac = "0.2"
 nom = "5"
 notify = "4"
-lewton = "0.10"
 ogg = "0.7"
 shellexpand = "2"
 thiserror = "1"
 toml = "0.5"
 
 [dependencies.serde]
+features = ["derive"]
 version = "1"
-features = [ "derive" ]
 
 [features]
-default = [ ]
-standalone = [ ]
+default = []
+standalone = []

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,12 @@ pub enum MusoError {
 
     #[error("Failed to parse format string")]
     FailedToParse,
+
+    #[error("Directory components in format string can't contain optionals")]
+    OptionalInDir,
+
+    #[error("File component must have one required placeholder (except from {{ext}})")]
+    RequiredInFile,
 }
 
 pub type AnyResult<T> = std::result::Result<T, anyhow::Error>;

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -151,7 +151,7 @@ impl Metadata {
         let mut map = HashMap::new();
 
         for (key, value) in list {
-            let entry = map.entry(key).or_insert_with(|| vec![]);
+            let entry = map.entry(key).or_insert_with(Vec::new);
             entry.push(value);
         }
 

--- a/tests/format_string.rs
+++ b/tests/format_string.rs
@@ -1,86 +1,115 @@
-use std::str::FromStr;
+macro_rules! define_tests_for {
+    ($ext:ident) => {
+        #[cfg(test)]
+        mod $ext {
+            use std::str::FromStr;
 
-use muso::error::{AnyResult, MusoError};
-use muso::format::ParsedFormat;
-use muso::metadata::Metadata;
+            use muso::error::{AnyResult, MusoError};
+            use muso::format::ParsedFormat;
+            use muso::metadata::Metadata;
 
-fn complete_with_ok_format(ext: &str) -> AnyResult<()> {
-    let metadata = Metadata::from_path(format!("test_files/complete.{}", ext))?;
-    let format = ParsedFormat::from_str("{artist}/{album}/{disc}.{track} - {title}.{ext}")?;
+            #[test]
+            fn complete_with_ok_format() -> AnyResult<()> {
+                let ext = stringify!($ext);
+                let metadata = Metadata::from_path(format!("test_files/complete.{}", ext))?;
+                let format =
+                    ParsedFormat::from_str("{artist}/{album}/{disc}.{track} - {title}.{ext}")?;
 
-    assert_eq! {
-        Ok(format!("Album Artist/Album/1.1 - Title.{}", ext)),
-        format.build_path(&metadata, false)
+                assert_eq! {
+                    Ok(format!("Album Artist/Album/1.1 - Title.{}", ext)),
+                    format.build_path(&metadata, false)
+                };
+
+                Ok(())
+            }
+
+            #[test]
+            fn partial_with_ok_format() -> AnyResult<()> {
+                let ext = stringify!($ext);
+                let metadata = Metadata::from_path(format!("test_files/partial.{}", ext))?;
+                let format = ParsedFormat::from_str("{artist}/{disc}.{track} - {title}.{ext}")?;
+
+                assert_eq! {
+                    Ok(format!("Artist/1.1 - Title.{}", ext)),
+                    format.build_path(&metadata, false)
+                };
+
+                Ok(())
+            }
+
+            #[test]
+            fn both_with_ok_optional_format() -> AnyResult<()> {
+                let ext = stringify!($ext);
+                let metadata = Metadata::from_path(format!("test_files/partial.{}", ext))?;
+                let format = ParsedFormat::from_str("{artist}/{album?} - {title}.{ext}")?;
+
+                assert_eq! {
+                    Ok(format!("Artist/ - Title.{}", ext)),
+                    format.build_path(&metadata, false)
+                };
+
+                let metadata = Metadata::from_path(format!("test_files/complete.{}", ext))?;
+
+                assert_eq!(
+                    Ok(format!("Album Artist/Album - Title.{}", ext)),
+                    format.build_path(&metadata, false)
+                );
+
+                Ok(())
+            }
+
+            #[test]
+            fn bad_optional_formats() -> AnyResult<()> {
+                let ext = stringify!($ext);
+                let metadata = Metadata::from_path(format!("test_files/partial.{}", ext))?;
+                let format = ParsedFormat::from_str("{artist}/{album?}/{title}.{ext}")?;
+
+                assert_eq! {
+                    Err(MusoError::OptionalInDir),
+                    format.build_path(&metadata, false)
+                };
+
+                let format = ParsedFormat::from_str("{artist}/{title?}.{ext}")?;
+
+                assert_eq! {
+                    Err(MusoError::RequiredInFile),
+                    format.build_path(&metadata, false)
+                }
+
+                Ok(())
+            }
+
+            #[test]
+            fn bad_file_format() -> AnyResult<()> {
+                let ext = stringify!($ext);
+                let metadata = Metadata::from_path(format!("test_files/partial.{}", ext))?;
+                let format = ParsedFormat::from_str("{artist}/foo.{ext}")?;
+
+                assert_eq! {
+                    Err(MusoError::RequiredInFile),
+                    format.build_path(&metadata, false)
+                };
+
+                Ok(())
+            }
+
+            #[test]
+            fn partial_with_bad_format() -> AnyResult<()> {
+                let ext = stringify!($ext);
+                let metadata = Metadata::from_path(format!("test_files/partial.{}", ext))?;
+                let format = ParsedFormat::from_str("{artist}/{album}")?;
+
+                assert_eq! {
+                    Err(MusoError::MissingTag{ tag: "album".into() }),
+                    format.build_path(&metadata, false)
+                };
+
+                Ok(())
+            }
+        }
     };
-
-    Ok(())
 }
 
-fn partial_with_ok_format(ext: &str) -> AnyResult<()> {
-    let metadata = Metadata::from_path(format!("test_files/partial.{}", ext))?;
-    let format = ParsedFormat::from_str("{artist}/{disc}.{track} - {title}.{ext}")?;
-
-    assert_eq! {
-        Ok(format!("Artist/1.1 - Title.{}", ext)),
-        format.build_path(&metadata, false)
-    };
-
-    Ok(())
-}
-
-fn partial_with_bad_format(ext: &str) -> AnyResult<()> {
-    let metadata = Metadata::from_path(format!("test_files/partial.{}", ext))?;
-    let format = ParsedFormat::from_str("{artist}/{album}")?;
-
-    assert_eq! {
-        Err(MusoError::MissingTag{ tag: "album".into() }),
-        format.build_path(&metadata, false)
-    };
-
-    Ok(())
-}
-
-#[test]
-fn complete_flac_with_ok_format() -> AnyResult<()> {
-    complete_with_ok_format("flac")
-}
-
-#[test]
-fn partial_flac_with_ok_format() -> AnyResult<()> {
-    partial_with_ok_format("flac")
-}
-
-#[test]
-fn partial_flac_with_bad_format() -> AnyResult<()> {
-    partial_with_bad_format("flac")
-}
-
-#[test]
-fn complete_mp3_with_ok_format() -> AnyResult<()> {
-    complete_with_ok_format("mp3")
-}
-
-#[test]
-fn partial_mp3_with_ok_format() -> AnyResult<()> {
-    partial_with_ok_format("mp3")
-}
-
-#[test]
-fn partial_mp3_with_bad_format() -> AnyResult<()> {
-    partial_with_bad_format("mp3")
-}
-
-#[test]
-fn complete_ogg_with_ok_format() -> AnyResult<()> {
-    complete_with_ok_format("ogg")
-}
-
-#[test]
-fn partial_ogg_with_ok_format() -> AnyResult<()> {
-    partial_with_ok_format("ogg")
-}
-
-#[test]
-fn partial_ogg_with_bad_format() -> AnyResult<()> {
-    partial_with_bad_format("ogg")
-}
+define_tests_for!(flac);
+define_tests_for!(mp3);
+define_tests_for!(ogg);


### PR DESCRIPTION
This PR adds support for optional tags on placeholders as requested and explained on #8. Closes #8.